### PR TITLE
Added flags to display only unicode characters or url encoded string

### DIFF
--- a/unisub/main.go
+++ b/unisub/main.go
@@ -8,8 +8,12 @@ import (
 )
 
 func main() {
+
 	var silent bool
 	flag.BoolVar(&silent, "silent", false, "enable silnet mode")
+	var urlEncodeOnly bool
+	flag.BoolVar(&urlEncodeOnly, "encode", false, "display only url econded string")
+
 	flag.Parse()
 	
 	if flag.NArg() < 1 {
@@ -27,6 +31,8 @@ func main() {
 	for _, s := range subs {
 		if silent {
 			fmt.Printf("%c\n", s)
+		} else if urlEncodeOnly {
+			fmt.Printf("%s\n", url.QueryEscape(string(s)))
 		} else {
 			fmt.Printf("fallback: %c %U %s\n", s, s, url.QueryEscape(string(s)))
 		}		
@@ -41,6 +47,8 @@ func main() {
 		if strings.ToLower(string(s)) == char {
 			if silent {
 				fmt.Printf("%c\n", s)
+			} else if urlEncodeOnly {
+				fmt.Printf("%s\n", url.QueryEscape(string(s)))
 			} else {
 				fmt.Printf("toLower: %c %U %s\n", s, s, url.QueryEscape(string(s)))
 			}
@@ -49,6 +57,8 @@ func main() {
 		if strings.ToUpper(string(s)) == char {
 			if silent {
 				fmt.Printf("%c\n", s)
+			} else if urlEncodeOnly {
+				fmt.Printf("%s\n", url.QueryEscape(string(s)))
 			} else {
 				fmt.Printf("toUpper: %c %U %s\n", s, s, url.QueryEscape(string(s)))
 			}

--- a/unisub/main.go
+++ b/unisub/main.go
@@ -8,22 +8,28 @@ import (
 )
 
 func main() {
+	var silent bool
+	flag.BoolVar(&silent, "silent", false, "enable silnet mode")
 	flag.Parse()
-
-	char := flag.Arg(0)
+	
 	if flag.NArg() < 1 {
 		fmt.Println("usage: unisub <char>")
 		return
 	}
-
-	subs, ok := translations[rune(char[0])]
+	
+	char := flag.Arg(0)
+		subs, ok := translations[rune(char[0])]
 	if !ok {
 		fmt.Println("no substitutions found")
 		return
 	}
 
 	for _, s := range subs {
-		fmt.Printf("fallback: %c %U %s\n", s, s, url.QueryEscape(string(s)))
+		if silent {
+			fmt.Printf("%c\n", s)
+		} else {
+			fmt.Printf("fallback: %c %U %s\n", s, s, url.QueryEscape(string(s)))
+		}		
 	}
 
 	for cp := 1; cp < 0x10FFFF; cp++ {
@@ -33,11 +39,19 @@ func main() {
 		}
 
 		if strings.ToLower(string(s)) == char {
-			fmt.Printf("toLower: %c %U %s\n", s, s, url.QueryEscape(string(s)))
+			if silent {
+				fmt.Printf("%c\n", s)
+			} else {
+				fmt.Printf("toLower: %c %U %s\n", s, s, url.QueryEscape(string(s)))
+			}
 		}
 
 		if strings.ToUpper(string(s)) == char {
-			fmt.Printf("toUpper: %c %U %s\n", s, s, url.QueryEscape(string(s)))
+			if silent {
+				fmt.Printf("%c\n", s)
+			} else {
+				fmt.Printf("toUpper: %c %U %s\n", s, s, url.QueryEscape(string(s)))
+			}
 		}
 	}
 }


### PR DESCRIPTION
Hey!

I have added the two flags ``silent`` and ``encode`` which makes easy to fuzz things by easily copy pasting or by writing the the list of characters to the files and passing it to the burp intruder or any other tools.

Please accept the merge request If you think it doesn't break anything.

Thanks