### PR TITLE
Add -i flag to filter-resolved

### DIFF
--- a/filter-resolved/main.go
+++ b/filter-resolved/main.go
@@ -13,7 +13,9 @@ func main() {
 
 	// configure the concurrency flag
 	concurrency := 20
+	var invert bool
 	flag.IntVar(&concurrency, "c", 20, "Set the concurrency level")
+	flag.BoolVar(&invert, "i", false, "Invert results")
 
 	// parse the flags
 	flag.Parse()
@@ -38,7 +40,7 @@ func main() {
 		go func() {
 			for domain := range jobs {
 				_, err := net.ResolveIPAddr("ip4", domain)
-				if err != nil {
+				if err != nil != invert {
 					continue
 				}
 				fmt.Println(domain)


### PR DESCRIPTION
The `-i` flag allows you to invert the results, i.e. filter for hosts that do _not_ resolve. This can be useful for detecting subdomains vulnerable to takeover (e.g. hosts pointing to some Azure services such as App Services or Service Fabric).